### PR TITLE
chore(ci): Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install just
-      uses: extractions/setup-just@v1
+      uses: extractions/setup-just@v2
     - name: Check just syntax
       run: |
         find "./" -type f -name "*.just" | while read -r file; do


### PR DESCRIPTION
extractions/setup-just@v2 bumps the version of nodejs used to 20 - should silence the 'node 16 is deprecated' messages